### PR TITLE
use border to make it clear when input option is active

### DIFF
--- a/themes/Github-Light-Theme-Gray-color-theme.json
+++ b/themes/Github-Light-Theme-Gray-color-theme.json
@@ -75,6 +75,8 @@
     // input
     "input.border": "#b2b2b2",
     "input.background": "#f0f0f0",
+    "inputOption.activeBorder": "#000000",
+    "inputOption.activeForeground": "#000000",
     "dropdown.border": "#b2b2b2",
     "dropdown.background": "#f0f0f0",
     "dropdown.listBackground": "#f0f0f0",

--- a/themes/Github-Light-Theme-color-theme.json
+++ b/themes/Github-Light-Theme-color-theme.json
@@ -75,6 +75,8 @@
     // input
     "input.border": "#b2b2b2",
     "input.background": "#ffffff",
+    "inputOption.activeBorder": "#000000",
+    "inputOption.activeForeground": "#000000",
     "dropdown.border": "#b2b2b2",
     "dropdown.background": "#ffffff",
     "dropdown.listBackground": "#ffffff",


### PR DESCRIPTION
Thanks for your work on this theme, which has been easy on my eyes!

I found it hard to tell when an input option was active or inactive. Take, for example, the option to use the "ignore files" settings. 

Here is what it looks like before my change (inactive, active):
![before-theme](https://user-images.githubusercontent.com/3445370/85643672-aed0aa80-b649-11ea-8384-0c7ea505b186.jpg)

And here's after my change (inactive, active):
![after-theme](https://user-images.githubusercontent.com/3445370/85643714-c871f200-b649-11ea-8bf4-be8e812244c0.jpg)

Notice the dark border. I find this makes it easier to tell when the option is active.

(The example uses the white theme, but it looks similar with the gray theme. )